### PR TITLE
security: upgrade bundled npm in base image to clear scan findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node:22-alpine
 
 RUN apk update && apk upgrade --no-cache
 
+# Upgrade the npm CLI bundled in the base image: node:22-alpine ships npm 10.9.8,
+# whose transitive deps (tar, sigstore, picomatch, brace-expansion, ...) trip the
+# Grype scan. Upgrading clears the critical tar advisory and most of the rest.
+RUN npm install -g npm@latest
+
 COPY . /app
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

GitHub code scanning (Grype, via `anchore/scan-action` in `delivery.yml`) reports **17** vulnerabilities on the Docker image. **14 of them — including the one Critical that fails the delivery build — come from the npm CLI bundled inside `node:22-alpine` (v10.9.8), not from application dependencies.** The app's own `node_modules` scans clean.

This upgrades the global npm CLI in the image, which pulls in fixed versions of `tar`, `sigstore`, `picomatch`, `brace-expansion`, and `ip-address`.

## Impact

| Source | Before | After |
|---|---|---|
| Bundled npm CLI (tar, sigstore, picomatch, brace-expansion, ip-address) | 14 | 2 |
| Alpine busybox `CVE-2025-60876` | 3 | 3 |
| **Total** | **17** | **5** |

- Removes the **Critical `tar`** advisory (`GHSA-23hp-3jrh-7fpw`, fixed in 7.5.19) — the only finding matching the CI fail condition (`only-fixed` + `severity-cutoff: critical`), so the scan now passes.

### Remaining 5 (no fix available to us)
- 3× busybox / ssl_client `CVE-2025-60876` (Medium) — Alpine package, **not yet patched upstream**; the Dockerfile already runs `apk upgrade --no-cache`.
- `brace-expansion` (High) + `tar` (Medium) — still buried in npm's own dependency tree; no npm release resolves them yet.

Verified locally by building the image with the change and rescanning with Grype.